### PR TITLE
記事の並べ替えの実装

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -4,6 +4,7 @@ const projectCollection = defineCollection({
   type: 'content',
   schema: z.object({
     draft: z.boolean(),
+    order: z.number().optional(),
     title: z.string(),
     category: z.array(z.string()),
     detail: z.string(),

--- a/src/content/projects/clinic_calendar.md
+++ b/src/content/projects/clinic_calendar.md
@@ -1,5 +1,6 @@
 ---
 draft: false
+order: 1
 title: '診療日カレンダー'
 category:
   - WordPress

--- a/src/content/projects/event_calender.md
+++ b/src/content/projects/event_calender.md
@@ -1,5 +1,6 @@
 ---
 draft: false
+order: 2
 title: 'イベント情報掲載'
 category:
   - WordPress

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,8 +11,27 @@ import '@fontsource/zen-maru-gothic/400.css';
 import '@fontsource-variable/quicksand';
 
 import { getCollection } from 'astro:content';
-const projectEntries = await getCollection('projects', ({data}) => {
-	return data.draft !== true;
+const projectAllEntries = await getCollection('projects');
+
+// 下書きを除外＆並び順調整
+const publishEntries = projectAllEntries
+.filter(
+	(post) => !post.data.draft
+)
+.sort((a, b) => {
+	if (!a) return 1;
+	if (!b) return -1;
+
+	const orderA = a.data?.order ?? Infinity;
+	const orderB = b.data?.order ?? Infinity;
+
+	// 並び順が設定されているものは並び替える
+	if ( orderA !== Infinity || orderB !== Infinity ) {
+		return orderA - orderB;
+	}
+
+	// 並び順が設定されていないものはスラッグ名で並び替える
+	return a.slug.localeCompare(b.slug);
 });
 ---
 
@@ -93,7 +112,7 @@ const projectEntries = await getCollection('projects', ({data}) => {
 						<h2 class="c-heading" data-subtext="Browse My Recent Projects">制作物</h2>
 						<ul class="p-projectList">
 							{
-								projectEntries.map((projectPostEntry) => (
+								publishEntries.map((projectPostEntry) => (
 									<li class="p-projectList__item">
 										<a href={`/projects/${projectPostEntry.slug}`}>
 											<div class="p-projectList__thumbnail"><img src={projectPostEntry.data.thumbnail} alt="" /></div>


### PR DESCRIPTION
### 変更内容
- projectコンテンツコレクション設定に並び替え用の項目をオプション設定として追加。
- トップページのproject一覧にorderによる並べ替えを追加。
   - orderが設定されている記事はその順番で並べる。
   - orderが設定されていない記事はslug名で並べる。