### PR TITLE
Hotfix: Skills.astro の import 修正

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import Footer from '../components/Footer.astro';
 
 import Mainvisual from '../components/Mainvisual.astro';
 import About from '../components/Top_about.astro';
-import Skills from '../components/skills.astro';
+import Skills from '../components/Skills.astro';
 
 import '../styles/global.css';
 import '@fontsource/zen-maru-gothic/400.css';


### PR DESCRIPTION
本番ビルドでエラーとなっていた import パスの大文字小文字不一致を修正しました。
- index.astro の `skills.astro` → `Skills.astro`
- 緊急修正のため hotfix ブランチ経由で main に反映します